### PR TITLE
Make the bazelrc configurable

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -37,6 +37,10 @@ inputs:
     description: GitHub token to query Bazelisk releases
     required: false
     default: ${{ github.token }}
+  bazelrc-name:
+    description: The name of the .bazelrc file if changed with the --bazelrc flag
+    required: false
+    default: ".bazelrc"
 
 runs:
   using: node20

--- a/config.js
+++ b/config.js
@@ -15,7 +15,8 @@ const platform = os.platform()
 let bazelDisk = core.toPosixPath(`${homeDir}/.cache/bazel-disk`)
 let bazelRepository = core.toPosixPath(`${homeDir}/.cache/bazel-repo`)
 let bazelOutputBase = `${homeDir}/.bazel`
-let bazelrcPaths = [core.toPosixPath(`${homeDir}/.bazelrc`)]
+let bazelrcName = core.getInput('bazelrc-name') || '.bazelrc'
+let bazelrcPaths = [core.toPosixPath(`${homeDir}/${bazelrcName}`)]
 let userCacheDir = `${homeDir}/.cache`
 
 switch (platform) {
@@ -28,7 +29,7 @@ switch (platform) {
     bazelOutputBase = 'D:/_bazel'
     userCacheDir = `${homeDir}/AppData/Local`
     if (process.env.HOME) {
-      bazelrcPaths.push(core.toPosixPath(`${process.env.HOME}/.bazelrc`))
+      bazelrcPaths.push(core.toPosixPath(`${process.env.HOME}/${bazelrcName}`))
     }
     break
 }


### PR DESCRIPTION
In our github actions, we run bazel with the bazelrc flag set.  It would be nice if we could configure the name of the bazelrc so that we could get the benefit of caching without having to  change all of our setups.