### PR TITLE
Set octokit's baseUrl explicitly to make it work with self-hosted GitHub Enterprise Servers

### DIFF
--- a/index.js
+++ b/index.js
@@ -70,7 +70,9 @@ async function downloadBazelisk() {
   }
 
   const token = core.getInput('token')
-  const octokit = github.getOctokit(token)
+  const octokit = github.getOctokit(token, {
+    baseUrl: 'https://api.github.com'
+  })
   const { data: releases } = await octokit.rest.repos.listReleases({
     owner: 'bazelbuild',
     repo: 'bazelisk'


### PR DESCRIPTION
At my company we use a self-hosted [GitHub Enterprise Server](https://docs.github.com/en/enterprise-server@3.9/admin/overview/about-github-enterprise-server) and to use GitHub Actions from github.com we are [syncing them to a local organization](https://docs.github.com/en/enterprise-server@3.12/admin/github-actions/managing-access-to-actions-from-githubcom/manually-syncing-actions-from-githubcom). I tried to do this with https://github.com/bazel-contrib/setup-bazel however it fails to download bazelisk with this error:

```
Run synced-actions/bazel-contrib-setup-bazel@0.8.4
Configure Bazel
Setup Bazelisk
  Error: HttpError: Not Found
      at /runner/_work/_actions/synced-actions/bazel-contrib-setup-bazel/0.8.4/dist/node_modules/@octokit/request/dist-node/index.js:124:1
      at processTicksAndRejections (node:internal/process/task_queues:95:5)
      at downloadBazelisk (/runner/_work/_actions/synced-actions/bazel-contrib-setup-bazel/0.8.4/dist/index.js:74:1)
      at setupBazelisk (/runner/_work/_actions/synced-actions/bazel-contrib-setup-bazel/0.8.4/dist/index.js:43:1)
      at setupBazel (/runner/_work/_actions/synced-actions/bazel-contrib-setup-bazel/0.8.4/dist/index.js:26:1)
      at run (/runner/_work/_actions/synced-actions/bazel-contrib-setup-bazel/0.8.4/dist/index.js:12:1)
```

The issue seems to be that `octokit.rest.repos.listReleases` defaults to using the GitHub API of the instance it's running on (in my case our GitHub Enterprise Server's API), so it is checking the releases of the `bazelbuild/bazelisk` repository on our internal GitHub Enterprise Server, where that repository doesn't exist.

This PR adds a [baseUrl](https://github.com/octokit/octokit.js?tab=readme-ov-file#constructor-options:~:text=See%20Authentication%20below.-,baseUrl,-String) pointing to github.com's API endpoint. This is the default behavior when running on github.com, so this only changes the behavior when running in an environment where the API endpoint is different (I believe this is only GitHub Enterprise Servers). The change results in always looking for the `bazelbuild/bazelisk` repository on github.com, which is the behavior most users would expect in my opinion.