### PR TITLE
Enable caches for all Bazel commands, not just build-related ones.

### DIFF
--- a/config.js
+++ b/config.js
@@ -47,7 +47,7 @@ const diskCacheConfig = core.getInput('disk-cache')
 const diskCacheEnabled = diskCacheConfig !== 'false'
 let diskCacheName = 'disk'
 if (diskCacheEnabled) {
-  bazelrc.push(`build --disk_cache=${bazelDisk}`)
+  bazelrc.push(`common --disk_cache=${bazelDisk}`)
   if (diskCacheName !== 'true') {
     diskCacheName = `${diskCacheName}-${diskCacheConfig}`
   }
@@ -62,7 +62,7 @@ let repositoryCacheFiles = [
   'WORKSPACE'
 ]
 if (repositoryCacheEnabled) {
-  bazelrc.push(`build --repository_cache=${bazelRepository}`)
+  bazelrc.push(`common --repository_cache=${bazelRepository}`)
   if (repositoryCacheConfig !== 'true') {
     repositoryCacheFiles = Array(repositoryCacheConfig).flat()
   }


### PR DESCRIPTION
Caching applies to all commands,
cf. https://bazel.build/versions/8.0.0/reference/command-line-reference#flag--disk_cache.