### PR TITLE
Include repository cache files in the disk cache key.

### DIFF
--- a/config.js
+++ b/config.js
@@ -138,10 +138,11 @@ module.exports = {
   bazelrc,
   diskCache: {
     enabled: diskCacheEnabled,
-    files: repositoryCacheFiles.concat([
+    files: [
+      ...repositoryCacheFiles,
       '**/BUILD.bazel',
       '**/BUILD'
-    ]),
+    ],
     name: diskCacheName,
     paths: [bazelDisk]
   },

--- a/config.js
+++ b/config.js
@@ -138,10 +138,10 @@ module.exports = {
   bazelrc,
   diskCache: {
     enabled: diskCacheEnabled,
-    files: [
+    files: repositoryCacheFiles.concat([
       '**/BUILD.bazel',
       '**/BUILD'
-    ],
+    ]),
     name: diskCacheName,
     paths: [bazelDisk]
   },


### PR DESCRIPTION
Like BUILD file changes, changes to workspace dependencies can significantly affect the contents of the disk cache. Prior to this change, upreving dependencies wasn't itself sufficient to update the disk cache, resulting in repeatedly rebuilding dependencies until some subsequent commit happened to modify BUILD files.

One of my projects has a dependency that take several hours to build; I recently realized that the reason that *all* builds were taking several hours is that we hadn't modified any BUILD files since upreving that dependency. Hopefully this prevents other people from having similar issues!