### PR TITLE
Add disk-cache-files input to support multiple modules

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,6 +111,27 @@ Default `false`.
   ```
 </details>
 
+### `disk-cache-files`
+
+Specify custom disk cache files.
+
+Default `""`.
+
+<details>
+  <summary>Examples</summary>
+
+  #### Override disk cache files
+
+  ```yaml
+  - uses: bazel-contrib/setup-bazel@0.13.0
+    with:
+      disk-cache-files: |
+        **/BUILD.bazel
+        **/BUILD
+        custom/path/BUILD
+  ```
+</details>
+
 ### `external-cache`
 
 Cache `external/` repositories based on contents of `MODULE.bazel` and `WORKSPACE` files.

--- a/action.yml
+++ b/action.yml
@@ -21,6 +21,10 @@ inputs:
     description: Cache actions outputs based on BUILD
     required: false
     default: "false"
+  disk-cache-files:
+    description: Custom disk cache files
+    required: false
+    default: ""
   external-cache:
     description: Cache external 10MB+ repositories based on MODULE.bazel/WORKSPACE
     required: false

--- a/config.js
+++ b/config.js
@@ -53,6 +53,15 @@ if (diskCacheEnabled) {
   }
 }
 
+const diskCacheFilesConfig = core.getMultilineInput('disk-cache-files')
+let diskCacheFiles = [
+  '**/BUILD.bazel',
+  '**/BUILD'
+]
+if (diskCacheFilesConfig.length > 0) {
+  diskCacheFiles = diskCacheFilesConfig
+}
+
 const repositoryCacheConfig = core.getInput('repository-cache')
 const repositoryCacheEnabled = repositoryCacheConfig !== 'false'
 let repositoryCacheFiles = [
@@ -140,8 +149,7 @@ module.exports = {
     enabled: diskCacheEnabled,
     files: [
       ...repositoryCacheFiles,
-      '**/BUILD.bazel',
-      '**/BUILD'
+      ...diskCacheFiles
     ],
     name: diskCacheName,
     paths: [bazelDisk]


### PR DESCRIPTION
Fixes #67

Add support for overriding disk cache files for multiple modules in the repository.

* Add a new input `disk-cache-files` in `action.yml` to specify custom disk cache files.
* Update `config.js` to handle the new `disk-cache-files` input and override the `diskCache.files` array if provided.
* Update the documentation in `README.md` to include the new `disk-cache-files` input and provide examples of its usage.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/bazel-contrib/setup-bazel/pull/68?shareId=2cd25aa0-78be-4fb5-bc57-0e5e2120af63).