### PR TITLE
fix: automatic bazelisk installation when not available

### DIFF
--- a/dist/main/index.js
+++ b/dist/main/index.js
@@ -103279,12 +103279,16 @@ module.exports = /*#__PURE__*/JSON.parse('[[[0,44],"disallowed_STD3_valid"],[[45
 var __webpack_exports__ = {};
 const fs = __nccwpck_require__(9896)
 const { setTimeout: index_setTimeout } = __nccwpck_require__(6460)
+const { exec } = __nccwpck_require__(5317)
+const { promisify } = __nccwpck_require__(9023)
 const core = __nccwpck_require__(7484)
 const cache = __nccwpck_require__(5116)
 const github = __nccwpck_require__(3228)
 const glob = __nccwpck_require__(7206)
 const tc = __nccwpck_require__(3472)
 const config = __nccwpck_require__(700)
+
+const execAsync = promisify(exec)
 
 async function run() {
   try {
@@ -103311,7 +103315,12 @@ async function setupBazel() {
 
 async function setupBazelisk() {
   if (config.bazeliskVersion.length == 0) {
-    return
+    if (await isBazelAvailable()) {
+      core.info('Bazel or Bazelisk already available, skipping installation')
+      return
+    }
+    core.info('No bazelisk-version specified and bazel/bazelisk not found. Installing bazelisk v1.26.0.')
+    config.bazeliskVersion = 'v1.26.0'
   }
 
   core.startGroup('Setup Bazelisk')
@@ -103323,6 +103332,20 @@ async function setupBazelisk() {
   }
   core.addPath(toolPath)
   core.endGroup()
+}
+
+async function isBazelAvailable() {
+  try {
+    await execAsync('bazelisk version')
+    return true
+  } catch (error) {
+    try {
+      await execAsync('bazel version')
+      return true
+    } catch (error) {
+      return false
+    }
+  }
 }
 
 async function downloadBazelisk() {


### PR DESCRIPTION
I hit this issue and spent a lot of confused time figuring out why it didn't work (this was using ARC runners with the default docker images). Thought I may do everyone else a favour and fix it.

- Add automatic bazelisk installation when no version is specified and neither bazel nor bazelisk is available
- Fixes issue where users on self-hosted runners would get no clear notification when bazelisk wasn't installed

Fixes: #78