### PR TITLE
include architecture in cache key

### DIFF
--- a/config.js
+++ b/config.js
@@ -46,7 +46,7 @@ switch (platform) {
     break
 }
 
-const baseCacheKey = `setup-bazel-${cacheVersion}-${platform}`
+const baseCacheKey = `setup-bazel-${cacheVersion}-${platform}-${arch}`
 const bazelrc = core.getMultilineInput('bazelrc')
 
 const diskCacheConfig = core.getInput('disk-cache')

--- a/dist/main/index.js
+++ b/dist/main/index.js
@@ -52,7 +52,7 @@ switch (platform) {
     break
 }
 
-const baseCacheKey = `setup-bazel-${cacheVersion}-${platform}`
+const baseCacheKey = `setup-bazel-${cacheVersion}-${platform}-${arch}`
 const bazelrc = core.getMultilineInput('bazelrc')
 
 const diskCacheConfig = core.getInput('disk-cache')

--- a/dist/post/index.js
+++ b/dist/post/index.js
@@ -52,7 +52,7 @@ switch (platform) {
     break
 }
 
-const baseCacheKey = `setup-bazel-${cacheVersion}-${platform}`
+const baseCacheKey = `setup-bazel-${cacheVersion}-${platform}-${arch}`
 const bazelrc = core.getMultilineInput('bazelrc')
 
 const diskCacheConfig = core.getInput('disk-cache')


### PR DESCRIPTION
Otherwise, tests on macos-13 and macos-15 use the same cache key for Intel and Apple Silicon.

Note: I had some trouble regenerating the `dist` without introducing huge changes in the output. For that reason I skipped updating `index.js.map`.